### PR TITLE
Default to status=current if not status is passed

### DIFF
--- a/scripts/export.php
+++ b/scripts/export.php
@@ -38,6 +38,8 @@ class GP_Script_Export extends GP_Translation_Set_Script {
 				$filters[$option_details['key']] = $this->options[$option];
 			}
 		}
+		if ( empty( $filters['status'] ) )
+			$filters['status'] = 'current';
 		return $filters;
 	}
 }


### PR DESCRIPTION
Not passing a status makes the query horribly inefficient, so default
to current if not passed. Passing a status made the difference between
being able to export and not on a large install
(translate.wordpress.org).
